### PR TITLE
adds pgsql

### DIFF
--- a/yii2-alpine-supervisor-xdebug/Dockerfile
+++ b/yii2-alpine-supervisor-xdebug/Dockerfile
@@ -39,6 +39,7 @@ RUN apk --update add \
         mbstring \
         opcache \
         pdo_mysql \
+        pgsql \
         pdo_pgsql && \
     apk del \
         icu-dev \

--- a/yii2-alpine-supervisor/Dockerfile
+++ b/yii2-alpine-supervisor/Dockerfile
@@ -39,6 +39,7 @@ RUN apk --update add \
         mbstring \
         opcache \
         pdo_mysql \
+        pgsql \
         pdo_pgsql && \
     apk del \
         icu-dev \

--- a/yii2-alpine-xdebug/Dockerfile
+++ b/yii2-alpine-xdebug/Dockerfile
@@ -39,6 +39,7 @@ RUN apk --update add \
         mbstring \
         opcache \
         pdo_mysql \
+        pgsql \
         pdo_pgsql && \
     apk del \
         icu-dev \

--- a/yii2-alpine/Dockerfile
+++ b/yii2-alpine/Dockerfile
@@ -39,6 +39,7 @@ RUN apk --update add \
         mbstring \
         opcache \
         pdo_mysql \
+        pgsql \
         pdo_pgsql && \
     apk del \
         icu-dev \

--- a/zts-xdebug/Dockerfile
+++ b/zts-xdebug/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y \
         libpq-dev \
         --no-install-recommends \
   && rm -r /var/lib/apt/lists/* \
-  && docker-php-ext-install -j$(nproc) pdo_pgsql \
+  && docker-php-ext-install -j$(nproc) pgsql pdo_pgsql \
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
   && git clone https://github.com/krakjoe/pthreads.git \
     && ( \

--- a/zts/Dockerfile
+++ b/zts/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y \
         libpq-dev \
         --no-install-recommends \
   && rm -r /var/lib/apt/lists/* \
-  && docker-php-ext-install -j$(nproc) pdo_pgsql \
+  && docker-php-ext-install -j$(nproc) pgsql pdo_pgsql \
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
   && git clone https://github.com/krakjoe/pthreads.git \
     && ( \


### PR DESCRIPTION
Without pgsql functions useful for postgres are absent, e.g. pg_escape_bytea() function.
This adds pgsql.

Somehow some builds are failing regardless the changes.